### PR TITLE
Add AGENTS.md and fix deprecated GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,9 @@ jobs:
     name: PHP ${{ matrix.php }} Symfony ${{ matrix.symfony-versions }} ${{ matrix.description }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: ${{ matrix.php }}-${{ matrix.symfony-versions }}
@@ -44,10 +44,10 @@ jobs:
 
       - name: Set composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer
-        uses: actions/cache@v2.1.2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.symfony-versions }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/static_analyse.yaml
+++ b/.github/workflows/static_analyse.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **PHP Symfony Bundle library** (`macpaw/symfony-deprecated-routes`), not a standalone application. There is no server to start or database to connect to.
+
+### Prerequisites
+
+- PHP >= 8.1 (8.3 recommended) with extensions: mbstring, xml, curl, zip, intl, dom
+- Composer
+
+### Key commands
+
+| Task | Command |
+|---|---|
+| Install dependencies | `composer install` |
+| Run tests | `vendor/bin/phpunit` |
+| Lint (code style) | `vendor/bin/phpcs` |
+| Static analysis | `vendor/bin/phpstan analyse` |
+| Validate composer.json | `composer validate` |
+
+### Notes
+
+- No `composer.lock` is committed — `composer install` resolves latest compatible versions each time.
+- The `validate` script in `composer.json` shadows the `composer validate` command; Composer warns about this but it's harmless.
+- PHPStan runs at `level: max` — see `phpstan.neon` for excluded paths.
+- phpcs uses PSR-12 plus custom rules — see `phpcs.xml.dist`.
+- Tests include both unit (`tests/Unit/`) and functional (`tests/Functional/`) suites using a test kernel at `Macpaw\SymfonyDeprecatedRoutes\Tests\App`.
+- Docker (`docker-compose.yaml`) is only for multi-PHP-version testing; not needed for standard development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific development instructions and fixes CI failures from deprecated GitHub Actions.

### Changes

**AGENTS.md**
- Prerequisites (PHP 8.1+, Composer)
- Key commands table (install, test, lint, static analysis, validate)
- Non-obvious caveats (no lockfile, phpstan level max, validate script shadow, test kernel details)

**CI workflow fixes**
- `actions/checkout@v2` → `v4` (all 3 workflows)
- `actions/cache@v2` / `v2.1.2` → `v4` (`ci.yaml`)
- Deprecated `::set-output` → `$GITHUB_OUTPUT` (`ci.yaml`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1ff1b0c-b011-4d3a-a7bb-04f5c5421ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1ff1b0c-b011-4d3a-a7bb-04f5c5421ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

