### PR TITLE
chore: widen dependencies to support latest packages (2026-03-18)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,10 @@ jobs:
           - '6.4.*'
           - '7.0.*'
         include:
+          - description: 'Symfony 8'
+            php: '8.4'
+            symfony-versions: '8.0.*'
+            coverage: 'none'
           - description: 'Log Code Coverage'
             php: '8.3'
             symfony-versions: '^7.0'
@@ -60,6 +64,8 @@ jobs:
           composer require symfony/dependency-injection:${{ matrix.symfony-versions }} --no-update --no-scripts
           composer require symfony/http-kernel:${{ matrix.symfony-versions }} --no-update --no-scripts
           composer require symfony/routing:${{ matrix.symfony-versions }} --no-update --no-scripts
+          composer require symfony/event-dispatcher:${{ matrix.symfony-versions }} --no-update --no-scripts
+          composer require --dev symfony/framework-bundle:${{ matrix.symfony-versions }} --no-update --no-scripts
           composer require --dev symfony/yaml:${{ matrix.symfony-versions }} --no-update --no-scripts
           composer require --dev symfony/browser-kit:${{ matrix.symfony-versions }} --no-update --no-scripts
       - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: cs-fix rector
+
+cs-fix:
+	vendor/bin/phpcbf
+
+rector:
+	vendor/bin/rector process --config rector.php

--- a/composer.json
+++ b/composer.json
@@ -5,19 +5,19 @@
     "type": "library",
     "require": {
         "php": "^8.1",
-        "symfony/config": "^6.4 || ^7.0",
-        "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/http-kernel": "^6.4 || ^7.0",
-        "symfony/routing": "^6.4 || ^7.0",
-        "symfony/event-dispatcher": "^6.4 || ^7.0"
+        "symfony/config": "^6.4 || ^7.0 || ^8.0",
+        "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0",
+        "symfony/routing": "^6.4 || ^7.0 || ^8.0",
+        "symfony/event-dispatcher": "^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "symfony/browser-kit": "^6.0",
-        "phpunit/phpunit": "^10.5",
-        "squizlabs/php_codesniffer": "^3.8",
-        "symfony/yaml": "^6.4 || ^7.0",
-        "symfony/framework-bundle": "^6.4 || ^7.0",
-        "phpstan/phpstan-symfony": "^1.3 || ^2.0"
+        "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0",
+        "phpunit/phpunit": "^12.5",
+        "squizlabs/php_codesniffer": "^4.0",
+        "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
+        "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+        "phpstan/phpstan-symfony": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "squizlabs/php_codesniffer": "^4.0",
         "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
         "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
-        "phpstan/phpstan-symfony": "^2.0"
+        "phpstan/phpstan-symfony": "^2.0",
+        "rector/rector": "^2.3"
     },
     "autoload": {
         "psr-4": {
@@ -35,6 +36,12 @@
         }
     },
     "scripts": {
+        "cs-fix": [
+            "vendor/bin/phpcbf"
+        ],
+        "rector": [
+            "vendor/bin/rector process --config rector.php"
+        ],
         "validate": [
             "composer validate"
         ]

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -23,7 +23,19 @@
 
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
-            <property name="forbiddenFunctions" type="array" value="eval=>NULL,dd=>NULL,die=>NULL,var_dump=>NULL,dump=>NULL,sizeof=>count,delete=>unset,print=>echo,echo=>NULL,print_r=>NULL,create_function=>NULL"/>
+            <property name="forbiddenFunctions" type="array">
+                <element key="eval"/>
+                <element key="dd"/>
+                <element key="die"/>
+                <element key="var_dump"/>
+                <element key="dump"/>
+                <element key="sizeof" value="count"/>
+                <element key="delete" value="unset"/>
+                <element key="print" value="echo"/>
+                <element key="echo"/>
+                <element key="print_r"/>
+                <element key="create_function"/>
+            </property>
         </properties>
     </rule>
     <rule ref="Squiz.WhiteSpace.FunctionSpacing">

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withTypeCoverageLevel(0)
+    ->withDeadCodeLevel(0)
+    ->withCodeQualityLevel(0);

--- a/src/DeprecatedRoutesBundle.php
+++ b/src/DeprecatedRoutesBundle.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class DeprecatedRoutesBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Widened runtime Symfony constraints to include latest stable major (`^8.0`) while preserving existing supported majors; bumped dev tooling constraints to current stable majors; added compatibility fixes for PHPCS 4 config and Symfony bundle signature compatibility.

## Updated packages
| Package | Scope | Constraint change |
|---|---|---|
| `symfony/config` | require | `^6.4 || ^7.0` -> `^6.4 || ^7.0 || ^8.0` |
| `symfony/dependency-injection` | require | `^6.4 || ^7.0` -> `^6.4 || ^7.0 || ^8.0` |
| `symfony/http-kernel` | require | `^6.4 || ^7.0` -> `^6.4 || ^7.0 || ^8.0` |
| `symfony/routing` | require | `^6.4 || ^7.0` -> `^6.4 || ^7.0 || ^8.0` |
| `symfony/event-dispatcher` | require | `^6.4 || ^7.0` -> `^6.4 || ^7.0 || ^8.0` |
| `symfony/browser-kit` | require-dev | `^6.0` -> `^6.4 || ^7.0 || ^8.0` |
| `symfony/yaml` | require-dev | `^6.4 || ^7.0` -> `^6.4 || ^7.0 || ^8.0` |
| `symfony/framework-bundle` | require-dev | `^6.4 || ^7.0` -> `^6.4 || ^7.0 || ^8.0` |
| `phpunit/phpunit` | require-dev | `^10.5` -> `^12.5` |
| `squizlabs/php_codesniffer` | require-dev | `^3.8` -> `^4.0` |
| `phpstan/phpstan-symfony` | require-dev | `^1.3 || ^2.0` -> `^2.0` |

## Release-notes / changelog summary
- `symfony/*` (7.x -> 8.x support): Symfony 8.0 requires PHP >= 8.4 and removes deprecated APIs retained in 7.4; package constraints are widened to allow 8.x while preserving 6.4/7.x compatibility.
- `phpunit/phpunit` (10.x -> 12.x): PHPUnit 12 removes previously deprecated APIs (including legacy mock helpers) and raises baseline to PHP 8.3.
- `squizlabs/php_codesniffer` (3.x -> 4.x): PHPCS 4 contains breaking changes and requires updated ruleset syntax for array properties.
- `phpstan/phpstan-symfony` (1.x -> 2.x): 2.0 release removes legacy config options and tracks newer PHPStan APIs.

## Compatibility code/config changes (no consumer API removals)
- Updated `phpcs.xml.dist` forbidden-functions array property to PHPCS 4 `<element .../>` format.
- Added explicit `: void` return type to `DeprecatedRoutesBundle::build()` to match Symfony Bundle contract in newer versions and satisfy static analysis.
- No public classes/constants removed; no public method removed.

## Validation results
### Latest dependency set
- `composer update` ✅
- `vendor/bin/phpunit` ✅ (suite passes; existing risky-test notices remain)
- `vendor/bin/phpstan analyse` ✅
- `vendor/bin/phpcs` ✅

### Lowest dependency set
- `composer update --prefer-lowest` ✅
- `rm -rf var/cache/test && vendor/bin/phpunit` ✅

### BC checker
- `vendor/bin/roave-backward-compatibility-check` not available in this repository.

## Blocked packages
- None. All intended constraint widenings/bumps were applied successfully.

## CI follow-up
- Addressed failing PHPStan check by aligning `DeprecatedRoutesBundle::build()` return type with parent signature (`void`).
- Node.js 20 deprecation warning from GitHub Actions is workflow-maintenance noise and not related to package runtime compatibility changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61856f15-b3e6-4a63-bcbd-3b0bf3ebb3bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61856f15-b3e6-4a63-bcbd-3b0bf3ebb3bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

